### PR TITLE
Handle API 502s

### DIFF
--- a/src/draw.js
+++ b/src/draw.js
@@ -47,6 +47,9 @@
                     }
                     
                     this._setTimer();
+                }.bind(this),function(reason) {
+                    console.log("API failure.");
+                    this._setTimer();
                 }.bind(this));
                 
                 this.save();


### PR DESCRIPTION
This allows us to recover from the 502 errors the server spits out when it gets too busy. This fixes issue discussed in #4.